### PR TITLE
Add parsing of user-defined literals

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/core/AbstractSyntaxTree.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/core/AbstractSyntaxTree.kt
@@ -43,8 +43,8 @@ sealed class NodeAssignment : Node()
 sealed class NodeExpression : Node()
 {
     data class Bool(val value: Boolean) : NodeExpression()
-    data class Numeric(val value: Number) : NodeExpression()
-    data class Textual(val value: String) : NodeExpression()
+    data class Numeric(val value: Number, val type: Name?) : NodeExpression()
+    data class Textual(val value: String, val type: Name?) : NodeExpression()
     
     data class Variable(val name: Name) : NodeExpression()
     data class Function(val name: Name, val parameters: List<ParameterNode>) : NodeExpression()

--- a/src/main/kotlin/com/github/derg/transpiler/lexer/Parser.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/lexer/Parser.kt
@@ -125,8 +125,8 @@ private fun extractConstant(input: List<Token>, cursor: Int): Parsed
     // TODO: Implement handling of custom literals
     return when (val token = input.getOrNull(cursor))
     {
-        is Numeric -> NodeExpression.Numeric(token.value)
-        is Textual -> NodeExpression.Textual(token.value)
+        is Numeric -> NodeExpression.Numeric(token.value, token.type)
+        is Textual -> NodeExpression.Textual(token.value, token.type)
         is Keyword -> convertToBoolExpression(token) ?: return null
         else       -> return null
     } to cursor + 1

--- a/src/main/kotlin/com/github/derg/transpiler/lexer/Tokens.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/lexer/Tokens.kt
@@ -6,7 +6,6 @@ interface Foo
 }
 
 sealed class Token
-sealed class Literal : Token()
 
 /**
  * All symbols such as variables, functions, type, namespaces, packages, etc. must be given a unique name. The
@@ -103,11 +102,11 @@ data class Operator(val type: Type) : Token()
 }
 
 /**
- * The token holds a raw numerical literal of a specific [value].
+ * The token holds a raw numerical literal of a specific [value] and optional [type].
  */
-data class Numeric(val value: Number) : Literal()
+data class Numeric(val value: Number, val type: String?) : Token()
 
 /**
- * The token holds a raw textual literal of a specific [value].
+ * The token holds a raw textual literal of a specific [value] and optional [type].
  */
-data class Textual(val value: String) : Literal()
+data class Textual(val value: String, val type: String?) : Token()

--- a/src/test/kotlin/com/github/derg/transpiler/lexer/TestParser.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/lexer/TestParser.kt
@@ -13,9 +13,9 @@ import org.junit.jupiter.api.Test
 private fun Node.asList() = listOf(this)
 
 private val Boolean.e get() = Bool(this)
-private val Int.e get() = NodeExpression.Numeric(toBigDecimal())
-private val Double.e get() = NodeExpression.Numeric(toBigDecimal())
-private val String.e get() = NodeExpression.Textual(this)
+private val Int.e get() = NodeExpression.Numeric(toBigDecimal(), null)
+private val Double.e get() = NodeExpression.Numeric(toBigDecimal(), null)
+private val String.e get() = NodeExpression.Textual(this, null)
 
 /**
  * Helper for parsing a [input] source code string into an abstract syntax tree.
@@ -36,6 +36,9 @@ class TestParser
             assertEquals(true.e.asList(), parse("true"))
             assertEquals(false.e.asList(), parse("false"))
             assertEquals("Hello World".e.asList(), parse(""" "Hello World" """))
+            
+            assertEquals(NodeExpression.Numeric(0.toBigDecimal(), "s").asList(), parse("0s"))
+            assertEquals(NodeExpression.Textual("", "s").asList(), parse("\"\"s"))
         }
         
         @Test

--- a/src/test/kotlin/com/github/derg/transpiler/lexer/TestTokenizer.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/lexer/TestTokenizer.kt
@@ -3,7 +3,8 @@ package com.github.derg.transpiler.lexer
 import com.github.derg.transpiler.core.Localized
 import com.github.derg.transpiler.core.Location
 import com.github.derg.transpiler.lexer.Keyword.Type.*
-import com.github.derg.transpiler.lexer.Operator.Type.*
+import com.github.derg.transpiler.lexer.Operator.Type.ASSIGN
+import com.github.derg.transpiler.lexer.Operator.Type.MINUS
 import com.github.derg.transpiler.lexer.Structure.Type.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
@@ -63,18 +64,20 @@ class TestTokenizer
         @Test
         fun `Given numeric literal, when tokenizing, then correct number`()
         {
-            assertEquals(localisedOfAsList(0, 1, Numeric(0.toBigDecimal())), tokenize("0"))
-            assertEquals(localisedOfAsList(0, 1, Numeric(1.toBigDecimal())), tokenize("1"))
-            assertEquals(localisedOfAsList(0, 4, Numeric(3.14.toBigDecimal())), tokenize("3.14"))
-            assertEquals(localisedOfAsList(0, 2, Numeric(0.5.toBigDecimal())), tokenize(".5"))
+            assertEquals(localisedOfAsList(0, 1, Numeric(0.toBigDecimal(), null)), tokenize("0"))
+            assertEquals(localisedOfAsList(0, 1, Numeric(1.toBigDecimal(), null)), tokenize("1"))
+            assertEquals(localisedOfAsList(0, 4, Numeric(3.14.toBigDecimal(), null)), tokenize("3.14"))
+            assertEquals(localisedOfAsList(0, 2, Numeric(0.5.toBigDecimal(), null)), tokenize(".5"))
+            assertEquals(localisedOfAsList(0, 2, Numeric(0.toBigDecimal(), "s")), tokenize("0s"))
         }
         
         @Test
         fun `Given textual literal, when tokenizing, then correct string`()
         {
-            assertEquals(localisedOfAsList(0, 2, Textual("")), tokenize("\"\""))
-            assertEquals(localisedOfAsList(0, 5, Textual("foo")), tokenize("\"foo\""))
-            assertEquals(localisedOfAsList(0, 14, Textual("Hello World!")), tokenize("\"Hello World!\""))
+            assertEquals(localisedOfAsList(0, 2, Textual("", null)), tokenize("\"\""))
+            assertEquals(localisedOfAsList(0, 5, Textual("foo", null)), tokenize("\"foo\""))
+            assertEquals(localisedOfAsList(0, 14, Textual("Hello World!", null)), tokenize("\"Hello World!\""))
+            assertEquals(localisedOfAsList(0, 8, Textual("foo", "bar")), tokenize("\"foo\"bar"))
         }
         
         @Test
@@ -110,7 +113,7 @@ class TestTokenizer
         fun `Given simple literal expression, when tokenizing, then correct sequence`()
         {
             val expected = listOf(
-                localizedOf(0, 1, Numeric(0.toBigDecimal())),
+                localizedOf(0, 1, Numeric(0.toBigDecimal(), null)),
                 localizedOf(1, 1, Structure(SEMICOLON)),
             )
             
@@ -122,7 +125,7 @@ class TestTokenizer
         {
             val expected = listOf(
                 localizedOf(0, 1, Operator(MINUS)),
-                localizedOf(1, 1, Numeric(5.toBigDecimal())),
+                localizedOf(1, 1, Numeric(5.toBigDecimal(), null)),
                 localizedOf(2, 1, Structure(SEMICOLON)),
             )
             
@@ -216,7 +219,7 @@ class TestTokenizer
                     localizedOf(0, 3, Keyword(VAL)),
                     localizedOf(4, 8, Identifier("variable")),
                     localizedOf(13, 1, Operator(ASSIGN)),
-                    localizedOf(15, 2, Numeric(42.toBigDecimal())),
+                    localizedOf(15, 2, Numeric(42.toBigDecimal(), null)),
                     localizedOf(17, 1, Structure(SEMICOLON)),
                 )
                 


### PR DESCRIPTION
Closes #10

Parsing user-defined literals is helpful when a developer needs a custom type, and do not want to pollute the codebase with conversion functions. Instead, the developer will be able to specify the type with a simple syntax, by appending a identifier directly after the literal (i.e. `5s`, `"Hello World!"foo`, etc).